### PR TITLE
Exclude repositories from dupin's search

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,12 +120,28 @@ dupin update-repos myorg --token abcdef
 # save the list of repositories in a provided location
 dupin update-repos --file /tmp/organisation-repos.txt
 ```
+```bash
+# exclude some very large repositories from the scan
+dupin update-repos myorg --repo-exclusions organisation/large-repo.git
+```
 
 #### `--file`
 
 By default it writes to `ROOT/repository-urls` (you'll need to provide
 a `--root` argument to take advantage of this). You can specify an
 alternative file.
+
+#### `--repo-exclusions`
+
+This setting specifies Git repositories that should be excluded from the
+resulting list.
+
+Very large Git repositories cannot easily be scanned by TruffleHog, and
+therefor by Dupin. The resulting log file will likely be too large
+because of false positives and the scan itself will likely consume too
+much memory. You should use this option (or the corresponding config
+property) to exclude large repositories and use a different approach to
+check for secrets in those repositories.
 
 ### auto-scan-all
 
@@ -240,6 +256,9 @@ works.
 github_token: xxxxxxxx-github-token-xxxxxxxx
 organisation_name: your-organisation
 notification_email: recipient@example.com
+repo_exclusions:
+  - organisation/large-repo.git
+  - org2/another-excluded-repo.git
 smtp:
   host: smtp-server.example.com
   from: sender@example.com
@@ -278,6 +297,16 @@ repositories that should be scanned.
 
 Dupin uses this as a "to" address when it emails updates to your
 organisation's secrets.
+
+### Repository exclusions
+
+This property allows you to exclude specified Git repositories from
+the list of repos that will be scanned. This is particularly useful
+if you have some very large repositories that Dupin is unable to scan.
+
+The exclusions should be provided as a YAML list. Any repository that
+matches any of the provided strings will be excluded, so be specific
+(you should probably include .git at the end where possible).
 
 ### SMTP
 
@@ -319,3 +348,18 @@ gpg --armor --export <identity/email>
 
 If you provide a PGP key in the configuration, PGP encryption will be
 automatically enabled.
+
+## Development
+
+To run Dupin's tests, set up your virtualenv and install Dupin's
+requirements using the provided `requirements.txt` file. You can
+then use unittest in `discover` mode to run all the tests.
+
+```bash
+# your choice of virtualenv location
+VENV=.venv
+
+virtualenv $VENV
+$VENV/bin/pip install -r requirements.txt
+$VENV/bin/python -m unittest discover
+```

--- a/dupin/config.py
+++ b/dupin/config.py
@@ -5,6 +5,7 @@ class Config(object):
     github_token = None
     organisation_name = None
     notification_email = None
+    repo_exclusions = None
 
     smtp_host = None
     smtp_username = None
@@ -23,6 +24,7 @@ class Config(object):
                 self.github_token = data.get("github_token", None)
                 self.organisation_name = data.get("organisation_name", None)
                 self.notification_email = data.get("notification_email", None)
+                self.repo_exclusions = data.get("repo_exclusions", None)
 
                 self.smtp_host = data.get("smtp", {}).get("host", None)
                 self.smtp_username = data.get("smtp", {}).get("username", None)

--- a/dupin/dupin.py
+++ b/dupin/dupin.py
@@ -19,6 +19,8 @@ update_repos_parser = subparsers.add_parser("update-repos", help="Lookup all the
 update_repos_parser.add_argument("org", nargs='?', help="The name of the organisation to search (default: from config)")
 update_repos_parser.add_argument("--token", help="Access token for Github's API (default: from config)")
 update_repos_parser.add_argument("--file", help="write the list of repository URLs to this file (default: ROOT/repository-urls)")
+update_repos_parser.add_argument("--repo-exclusions", nargs='+',
+                                 help="Exclude matching repos from the resulting list (useful for very large repos that cannot be scanned)")
 
 scan_repo_parser = subparsers.add_parser("scan-repo", help="Look for secrets within a repository",
                                          epilog="Example: dupin scan https://github.com/guardian/dupin.git")
@@ -65,6 +67,7 @@ def main():
         setup(root)
     elif "update-repos" == opts.subcommand:
         org = opts.org or config.organisation_name
+        repo_exclusions = opts.repo_exclusions or config.repo_exclusions
         if org is None:
             update_repos_parser.print_help()
             sys.exit(1)
@@ -74,7 +77,7 @@ def main():
         else:
             filename = opts.file
 
-        update_organisation_repos(org, token, filename)
+        update_organisation_repos(org, token, filename, repo_exclusions)
     elif "scan-repo" == opts.subcommand:
         repo_location = opts.location
         scan_repo(repo_location, root)

--- a/dupin/organisation.py
+++ b/dupin/organisation.py
@@ -6,7 +6,7 @@ from github import Github
 from utils import printerr
 
 
-def update_organisation_repos(organisation, token, filename):
+def update_organisation_repos(organisation, token, filename, excludes):
     """Searches a Github organisation for repositories that can be
     cloned, writes discovered repo URLs to a local file."""
     github_client = Github(token)
@@ -16,14 +16,25 @@ def update_organisation_repos(organisation, token, filename):
 
     repos = org.get_repos("public")
     clone_urls = _clone_urls(repos)
+    filtered = filter_excluded_repos(clone_urls, excludes)
     with open(filename, "w") as f:
-        _write_repo_list(clone_urls, f)
+        _write_repo_list(filtered, f)
         printerr("Wrote list of repositories to {location}".format(location=filename))
     return
 
 
 def _clone_urls(repositories):
     return [ repo.clone_url for repo in repositories ]
+
+def filter_excluded_repos(repositories, excludes):
+    if excludes is None:
+        return repositories
+    else:
+        filtered = []
+        for repo in repositories:
+            if all(exclude not in repo for exclude in excludes):
+                filtered.append(repo)
+        return filtered
 
 def _write_repo_list(clone_urls, f):
     f.write("\n".join(clone_urls))

--- a/dupin/trufflehog/false_positives.py
+++ b/dupin/trufflehog/false_positives.py
@@ -4,7 +4,7 @@ import re
 yarn              = re.compile('^\s*\"?resolved(?:\":)? \"(?:https|git|git\+https)://.*(?:#|/)[a-f0-9]+\"')
 data_url          = re.compile('data:\w+/[\w+-]+;[^,]*,[a-zA-Z0-9+/=]+')
 flow_sig          = re.compile('^// flow-typed signature: [a-z0-9]+$')
-sys_images        = re.compile('/sys-images/Guardian/Pix/[\w/]+/\d{4}/\d{1,2}/\d{1,2}/\d+/[\w-]+\.(?:png|jpg|jpeg)')
+sys_images        = re.compile('/sys-images/[\w/]+/\d{4}/\d{1,2}/\d{1,2}/\d+/[\w-]+\.(?:png|jpg|jpeg)')
 gu_video          = re.compile('gu-video-[0-9a-f]+')
 json_allowed_hash = re.compile('^\s*\"(?:shasum|commit|id|mediaId)\":\s*\"[0-9a-f]+\",?$')
 capi_fixture      = re.compile('^{"response":{"')

--- a/dupin/trufflehog/false_positives.py
+++ b/dupin/trufflehog/false_positives.py
@@ -17,7 +17,7 @@ static_guim       = re.compile('http://static\.guim\.co\.uk/static/[a-f0-9]{40}/
 def false_positive(line):
     """Returns true if this line looks like a false positive.
     Tweak these to match your own requirements!
-    (See also /tests/false_positives.py)
+    (See also /tests/test_false_positives.py)
     """
     if yarn.search(line) or data_url.search(line) or flow_sig.search(line) or \
             sys_images.search(line) or gu_video.search(line) or json_allowed_hash.search(line) or \

--- a/tests/test_false_positives.py
+++ b/tests/test_false_positives.py
@@ -34,6 +34,7 @@ class TestFalsePositives(unittest.TestCase):
         self.assertTrue(false_positive('        <img class="this-is-the-nhs__hand this-is-the-nhs__hand--left" src="@Configuration.static.path/sys-images/Guardian/Pix/pictures/2016/1/7/1452167267487/handleftcompressor.png" />'))
         self.assertTrue(false_positive('      Item700.bestFor(image) should be (Some(s"$imageHost/img/static/sys-images/Guardian/Pix/pictures/2013/7/5/1373023097878/b6a5a492-cc18-4f30-9809-88467e07ebfa-460x276.jpeg?w=700&q=55&auto=format&usm=12&fit=max&s=1e7d3c46056f162deec921e3c21de647"))'))
         self.assertTrue(false_positive('          endWith("img/static/sys-images/Guardian/Pix/audio/video/2014/5/16/1400240928538/Nigel-Farage-LBC-debate-i-014.jpg?w=640&h=360&q=85&auto=format&sharp=10&s=642bf1757bcb095c924d2f3789857019")'))
+        self.assertTrue(false_positive('        "file":"http://static.guim.co.uk/sys-images/Guardian/About/General/2013/3/12/1363100797848/Meanwhile-back-in-the-liv-002.jpg",'))
 
     def test_gu_video(self):
         self.assertTrue(false_positive("        var desiredVideos = ['gu-video-111111111', 'gu-video-111111111111111111111111'];"))

--- a/tests/test_false_positives.py
+++ b/tests/test_false_positives.py
@@ -3,9 +3,9 @@ import unittest
 
 from dupin.trufflehog.false_positives import false_positive
 
-class TestStringMethods(unittest.TestCase):
+class TestFalsePositives(unittest.TestCase):
     """Tweak these to suit your use case
-    (See also /dupin/trufflehog/false_positives.py)
+    (See also /dupin/trufflehog/test_false_positives.py)
     """
 
     def test_returns_true_for_good_strings(self):

--- a/tests/test_organisation.py
+++ b/tests/test_organisation.py
@@ -1,0 +1,30 @@
+# coding=utf-8
+import unittest
+
+from dupin.organisation import filter_excluded_repos
+
+class TestOrganisation(unittest.TestCase):
+    excludes = ["organisation/foo", "organisation/bar", "org2/baz"]
+
+    def test_does_not_filter_if_excludes_is_none(self):
+        repos = ["https://github.com/guardian/dupin.git"]
+        self.assertEqual(filter_excluded_repos(repos, None), repos)
+
+    def test_does_not_filter_if_excludes_is_empty(self):
+        repos = ["https://github.com/guardian/dupin.git"]
+        self.assertEqual(filter_excluded_repos(repos, []), repos)
+
+    def test_filter_repos_inlcudes_unfiltered_repo(self):
+        repos = ["https://github.com/guardian/dupin.git"]
+        self.assertEqual(filter_excluded_repos(repos, self.excludes), repos)
+
+    def test_filter_excludes_matching_repo(self):
+        repos = ["https://github.com/guardian/dupin.git", "https://github.com/organisation/foo.git"]
+        self.assertEqual(filter_excluded_repos(repos, self.excludes), ["https://github.com/guardian/dupin.git"])
+
+    def test_filters_multiple_excluded_repos(self):
+        repos = ["https://github.com/organisation/foo.git", "git@github.com:org2/baz.git"]
+        self.assertFalse(filter_excluded_repos(repos, self.excludes))
+
+    def test_filters_exact_match(self):
+        self.assertFalse(filter_excluded_repos(["https://github.com/guardian/dupin.git"], ["https://github.com/guardian/dupin.git"]))

--- a/tests/test_trufflehog.py
+++ b/tests/test_trufflehog.py
@@ -1,0 +1,84 @@
+# coding=utf-8
+import unittest
+from textwrap import dedent
+
+from dupin.trufflehog.trufflehog import focus_diff, bcolors
+
+
+class TestTruffleHog(unittest.TestCase):
+    search = "!"
+
+    def test_returns_empty_string_if_search_not_found(self):
+        text = dedent("""\
+        Test text
+        No line matches""")
+        self.assertEqual(focus_diff(text, self.search), "")
+
+    def test_can_search_for_ctrl_char(self):
+        text = bcolors.WARNING + " Should match"
+        self.assertEqual(focus_diff(text, bcolors.WARNING), text)
+
+    def test_returns_context_for_matching_line(self):
+        text = dedent("""\
+        Line 1
+        Line 2
+        Line 3
+        This line matches!
+        Additional context
+        Still printed
+        Not this""")
+        expected = dedent("""\
+        Line 2
+        Line 3
+        This line matches!
+        Additional context
+        Still printed""")
+        self.assertEqual(focus_diff(text, self.search), expected)
+
+    def test_does_not_overlap_context(self):
+        text = dedent("""\
+        Line 1
+        Line 2
+        This line matches!
+        Another match!
+        Additional context
+        Still printed
+        Not this""")
+        expected = dedent("""\
+        Line 1
+        Line 2
+        This line matches!
+        Another match!
+        Additional context
+        Still printed""")
+        self.assertEqual(focus_diff(text, self.search), expected)
+
+    def test_does_not_overlap_multiple_contexts(self):
+        text = dedent("""\
+            not printed
+            context 1
+            context 2
+            This line matches!
+            context 3
+            context 4
+            not printed
+            context 5
+            context 6
+            Another match!
+            Match again!
+            context 7
+            context 8
+            not printed""")
+        expected = dedent("""\
+            context 1
+            context 2
+            This line matches!
+            context 3
+            context 4
+            context 5
+            context 6
+            Another match!
+            Match again!
+            context 7
+            context 8""")
+        self.assertEqual(focus_diff(text, self.search), expected)


### PR DESCRIPTION
Very large Git repositories cannot easily be scanned by TruffleHog, and thus also by Dupin. There may be other reasons why someone would want to exclude specific repositories from Dupin's searches.

To address these use cases, Dupin now supports `repo exclusions` when searching for an organistion's repositories. Any repo matching an exclusino will not be included. This property can be provided via config, or as an argument to the `update-repos` command.